### PR TITLE
bugfix/recursive-iterator

### DIFF
--- a/src/Filicious/File.php
+++ b/src/Filicious/File.php
@@ -855,16 +855,7 @@ class File
 	{
 		$iterator = $this->pathname->rootAdapter()->getIterator($this->pathname, func_get_args());
 
-		// cheap array creation
-		if (method_exists($iterator, 'toArray')) {
-			return $iterator->toArray();
-		}
-
-		$files = array();
-		foreach ($iterator as $file) {
-			$files[] = $file;
-		}
-		return $files;
+		return iterator_to_array($iterator, false);
 	}
 
 	/**

--- a/src/Filicious/Internals/AbstractAdapter.php
+++ b/src/Filicious/Internals/AbstractAdapter.php
@@ -517,9 +517,11 @@ abstract class AbstractAdapter
 	public function getIterator(Pathname $pathname, array $filter)
 	{
 		if (Util::hasBit($filter, File::LIST_RECURSIVE)) {
-			return new \RecursiveIteratorIterator(
-				new RecursivePathnameIterator($pathname, $filter)
-			);
+			$iterator = new RecursivePathnameIterator($pathname, $filter);
+			$mode = $iterator->shouldIncludeDirectories() ?
+				\RecursiveIteratorIterator::SELF_FIRST :
+				\RecursiveIteratorIterator::LEAVES_ONLY;
+			return new \RecursiveIteratorIterator($iterator, $mode);
 		}
 		else {
 			return new PathnameIterator($pathname, $filter);

--- a/src/Filicious/Internals/RecursivePathnameIterator.php
+++ b/src/Filicious/Internals/RecursivePathnameIterator.php
@@ -13,6 +13,8 @@
 
 namespace Filicious\Internals;
 
+use Filicious\File;
+
 /**
  * Filesystem iterator
  *
@@ -44,7 +46,7 @@ class RecursivePathnameIterator extends PathnameIterator
 	 * Returns an iterator for the current entry.
 	 *
 	 * @link http://php.net/manual/en/recursiveiterator.getchildren.php
-	 * @return RecursiveIterator An iterator for the current entry.
+	 * @return \RecursiveIterator An iterator for the current entry.
 	 */
 	public function getChildren()
 	{
@@ -54,5 +56,12 @@ class RecursivePathnameIterator extends PathnameIterator
 		);
 		$iterator->prepareFilters($this);
 		return $iterator;
+	}
+
+	public function shouldIncludeDirectories() {
+		if ($this->bitmask === null) {
+			$this->prepareFilters();
+		}
+		return File::LIST_DIRECTORIES === ($this->bitmask & File::LIST_DIRECTORIES);
 	}
 }


### PR DESCRIPTION
Fixed recursive iterator not decending into children (toArray won't decend).

Fixed not keeping directories for recursive iterator even if LIST_DIRECTORIES is set.
I'm not set on the method name `shouldIncludeDirectories`. Feel free to change that. 